### PR TITLE
Direct CMS AAA proxy addresses via local proxy

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -24,6 +24,8 @@ for arg in sys.argv:
             if not os.path.isfile('/etc/nogateway') and gateway:
                 dargs.append('--network=ralworker')
                 dargs.append('--add-host=xrootd.echo.stfc.ac.uk:172.28.1.1')
+                dargs.append('--add-host=cms-aaa-proxy695.gridpp.rl.ac.uk:172.28.1.1')
+                dargs.append('--add-host=cms-aaa-proxy719.gridpp.rl.ac.uk:172.28.1.1')
                 dargs.append('--label=xrootd-local-gateway=true')
             else:
                 dargs.append('--label=xrootd-local-gateway=false')


### PR DESCRIPTION
This should ensure that the WN requests can never access Echo data via AAA, hopefully meaning that AAA will be less frequently overloaded with requests and hence be more stable.

The underlying problem being:
1. RAL WNs running CMS jobs either cannot access a file in Echo, or the connection is dropped during running.
2. The WN asks the AAA service if the file is available.
3. The UK AAA-redirector confirms that RAL has the file
4. The file is accessed, via AAA.
5. The AAA service becomes overloaded and starts failing SAM tests, affecting our availability in the eyes of CMS.
   When very busy, jobs running on the WN are also likely to fail, which is inevitable.

Also see RT#229757.