### PR TITLE
Allow worker node gateway impersonation

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 from subprocess import Popen, PIPE
+from socket import getfqdn
 
 singularity = True
 if any('grid-workernode-c7' in arg for arg in sys.argv):
@@ -27,6 +28,7 @@ for arg in sys.argv:
                 dargs.append('--add-host=cms-aaa-proxy695.gridpp.rl.ac.uk:172.28.1.1')
                 dargs.append('--add-host=cms-aaa-proxy719.gridpp.rl.ac.uk:172.28.1.1')
                 dargs.append('--label=xrootd-local-gateway=true')
+                dargs.append('--env=XrdSecGSISRVNAMES=%s' % getfqdn())
             else:
                 dargs.append('--label=xrootd-local-gateway=false')
         else:


### PR DESCRIPTION
The on-node gateways impersonate xrootd.echo.stfc.ac.uk but have their own certificates,
while they do have SubjectAltNames for echo.stfc.ac.uk, *.echo.stfc.ac.uk and *.s3.echo.stfc.ac.uk
older versions of xrootd utilities (such as those built in to experiment frameworks) do not check
for SubjectAltNames and immediately fail with a cryptic "Auth Error".

See RT#229968 for more background on the issue.