### PR TITLE
Add less niceness to sub command to leave headroom

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -47,7 +47,7 @@ for arg in sys.argv:
 
 if '/' in dargs[-1] and not dargs[-1].startswith('-'):
     command = dargs.pop()
-    dargs = dargs + ['nice', '-n 15', command]
+    dargs = dargs + ['nice', '-n 10', command]
 
 p = Popen(dargs, stdout=PIPE, stderr=PIPE)
 output, err = p.communicate()


### PR DESCRIPTION
We run the whole of docker at -5 and it is good to have some space left for
even lower priority tasks, otherwise -5 - 15 = -20 which rounds to -19 (max).