### PR TITLE
Update AAA hostnames

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -25,8 +25,8 @@ for arg in sys.argv:
             if not os.path.isfile('/etc/nogateway') and gateway:
                 dargs.append('--network=ralworker')
                 dargs.append('--add-host=xrootd.echo.stfc.ac.uk:172.28.1.1')
-                dargs.append('--add-host=cms-aaa-proxy695.gridpp.rl.ac.uk:172.28.1.1')
-                dargs.append('--add-host=cms-aaa-proxy719.gridpp.rl.ac.uk:172.28.1.1')
+                dargs.append('--add-host=ceph-gw10.gridpp.rl.ac.uk:172.28.1.1')
+                dargs.append('--add-host=ceph-gw11.gridpp.rl.ac.uk:172.28.1.1')
                 dargs.append('--label=xrootd-local-gateway=true')
                 dargs.append('--env=XrdSecGSISRVNAMES=%s' % getfqdn())
                 dargs.append('--env=SINGULARITYENV_XrdSecGSISRVNAMES=%s' % getfqdn())


### PR DESCRIPTION
Per request in RT#279700, update the hostnames for AAA in Docker wrapper.

For background info, this is to solve the issue of RAL jobs failing to access Echo and falling back to using the AAA, and then trying to access the file again on Echo, but via the AAA proxies. To stop this happening, when the job tries to access Echo via one of the AAA proxies, it is redirected again to access Echo directly because of the extra lines in the `/etc/hosts` file.

```
172.28.1.1 cms-aaa-proxy695.gridpp.rl.ac.uk
172.28.1.1 cms-aaa-proxy719.gridpp.rl.ac.uk
```
Update this to the new hardware:
`cms-aaa-proxy695.gridpp.rl.ac.uk` → `ceph-gw10.gridpp.rl.ac.uk`
`cms-aaa-proxy719.gridpp.rl.ac.uk`  → `ceph-gw11.gridpp.rl.ac.uk`