### PR TITLE
Disable security options until tested.

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -56,11 +56,11 @@ for arg in sys.argv:
                 # code to run as root, and are generally more secure than adding capabilities.
                 #
                 # Enable unshare to be called (which is needed to create namespaces)
-                dargs.append('--security-opt seccomp=unconfined')
+                #dargs.append('--security-opt seccomp=unconfined')
                 # Allow /proc to be mounted in an unprivileged process namespace (as done by singularity exec -p)
-                dargs.append('--security-opt systempaths=unconfined')
+                #dargs.append('--security-opt systempaths=unconfined')
                 # Prevent any privilege escalation (prevents setuid programs from running)
-                dargs.append('--security-opt no-new-privileges')
+                #dargs.append('--security-opt no-new-privileges')
         else:
             dargs.append(arg)
     count += 1


### PR DESCRIPTION
The security options passed to Docker causes the containers to fail. The security options should be removed until they are tested or the route cause issue is found. 