### PR TITLE
Docker 20.10 bumps containerd version. The new containerd package is …

### DIFF
--- a/healthcheck_wn_condor
+++ b/healthcheck_wn_condor
@@ -356,7 +356,7 @@ then
     fi
 
  # Check that containerd is running
-    pidof docker-containerd > /dev/null 2>&1
+    pidof containerd > /dev/null 2>&1
     RC=$?
     if [ $RC -ne 0 ]
     then
@@ -364,7 +364,7 @@ then
     fi
 
  # Check that containers can be created successfully
-    sudo /usr/bin/docker run --rm -m 5m busybox date >/dev/null 2>&1
+    sudo /usr/bin/docker run --rm -m 6m busybox date >/dev/null 2>&1
     RC=$?
     if [ $RC -ne 0 ]
     then


### PR DESCRIPTION
…called "containerd" changing from "docker-containerd"

Bump memory requirement for test container. https://github.com/moby/moby/pull/41168