### PR TITLE
Remove Docker capability options - fix for Singularity

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -21,13 +21,9 @@ def args_create(argv):
     """
     dargs = []
 
-    # Allow singularity to work inside of Docker containers
+    # Allow singularity to bind local hosts file
     dargs.append('--env=SINGULARITY_BINDPATH=/etc/hosts')
-    dargs.append('--cap-add=SYS_ADMIN')
-    dargs.append('--cap-add=DAC_OVERRIDE')
-    dargs.append('--cap-add=SETUID')
-    dargs.append('--cap-add=SETGID')
-    dargs.append('--cap-add=SYS_CHROOT')
+
     # ATLAS fix for 21.0.XX release errors with frontier
     dargs.append('--env=SINGULARITYENV_FRONTIER_LOG_FILE=frontier.log')
 
@@ -50,7 +46,7 @@ def args_create(argv):
     # Allow /proc to be mounted in an unprivileged process namespace (as done by singularity exec -p)
     dargs.append('--security-opt=systempaths=unconfined')
     # Prevent any privilege escalation (prevents setuid programs from running)
-    #dargs.append('--security-opt=no-new-privileges')
+    dargs.append('--security-opt=no-new-privileges')
     # In addition, the following option is recommended for allowing unprivileged fuse mounts on kernels that support that.
     dargs.append('--device=/dev/fuse')
 

--- a/docker.py
+++ b/docker.py
@@ -5,7 +5,6 @@ import sys
 from subprocess import Popen, PIPE
 from socket import getfqdn
 
-
 def gateway():
     gateway_needed = False
     if any('atl' in arg for arg in sys.argv) or \
@@ -15,6 +14,9 @@ def gateway():
     return gateway_needed and not os.path.isfile('/etc/nogateway')
 
 def args_create(argv):
+    # Define major Singularity version
+    singularity_major_version = int(3)
+
     """
     Build the new list of command line arguments for command
         docker create
@@ -36,20 +38,34 @@ def args_create(argv):
     # It may trigger a SIGKILL signal to the pilot.
     dargs.append('--env=PILOT_NOKILL=1')
 
+    # For older Singularity versions we must define Docker capabilities.
+    # Newer Singularity versions rely on security-options
+    # This checks which image we are using and sets Docker create options accordingly
+    for arg in argv:
+        # Check for old image containing Singularity 2
+        if 'grid-workernode' in arg and arg.endswith(':2019-07-02.1'):
+            singularity_major_version = int(2)
+            break
 
-    # Set security options to allow unprivileged singularity to run
-    # The options are secure as long as the system administrator controls the images and does not allow user
-    # code to run as root, and are generally more secure than adding capabilities.
-    #
-    # Enable unshare to be called (which is needed to create namespaces)
-    dargs.append('--security-opt=seccomp=unconfined')
-    # Allow /proc to be mounted in an unprivileged process namespace (as done by singularity exec -p)
-    dargs.append('--security-opt=systempaths=unconfined')
-    # Prevent any privilege escalation (prevents setuid programs from running)
-    dargs.append('--security-opt=no-new-privileges')
-    # In addition, the following option is recommended for allowing unprivileged fuse mounts on kernels that support that.
-    dargs.append('--device=/dev/fuse')
-
+    if singularity_major_version == 2:
+        dargs.append('--cap-add=SYS_ADMIN')
+        dargs.append('--cap-add=DAC_OVERRIDE')
+        dargs.append('--cap-add=SETUID')
+        dargs.append('--cap-add=SETGID')
+        dargs.append('--cap-add=SYS_CHROOT')
+    elif singularity_major_version == 3:
+        # Set security options to allow unprivileged singularity to run
+        # The options are secure as long as the system administrator controls the images and does not allow user
+        # code to run as root, and are generally more secure than adding capabilities.
+        #
+        # Enable unshare to be called (which is needed to create namespaces)
+        dargs.append('--security-opt=seccomp=unconfined')
+        # Allow /proc to be mounted in an unprivileged process namespace (as done by singularity exec -p)
+        dargs.append('--security-opt=systempaths=unconfined')
+        # Prevent any privilege escalation (prevents setuid programs from running)
+        dargs.append('--security-opt=no-new-privileges')
+        # In addition, the following option is recommended for allowing unprivileged fuse mounts on kernels that support that.
+        dargs.append('--device=/dev/fuse')
 
     if gateway():
         dargs.append('--label=xrootd-local-gateway=true')


### PR DESCRIPTION
Move away from using Docker capabilities and use --security-opt when running Singularity 3.x