### PR TITLE
Refactor the shebang line to call Python 3

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import re


### PR DESCRIPTION
This change allows the docker.py script to call `/usr/bin/env Python3`