### PR TITLE
Add check to detect locked filesystem

### DIFF
--- a/healthcheck_wn_condor
+++ b/healthcheck_wn_condor
@@ -172,6 +172,18 @@ if [ ! -f /usr/sbin/xfs_info ]; then
 fi
 # end of xfs_info check
 
+# Check to confirm xfs mountpoint is queryable
+# If it's not, this can lock containers on the workernode and cause
+# the "Zombie container" issue where pilot containers aren't deleted
+debug "Checking if /pool is queryable"
+timeout 5 xfs_info /pool > /dev/null 2>&1
+RC=$?
+if [ $RC -eq 124 ]
+then
+    fatal_exit "Problem: /pool is not queryable and timed out. Likely Docker containers aren't being deleted. Check CVMFS repos"
+fi
+# end check if /pool is queryable
+
 # Check if /pool is formatted correctly
 debug "Checking if /pool is formatted correctly"
 xfs_info /pool | grep ftype=1 > /dev/null 2>&1


### PR DESCRIPTION
This check detects if the /pool mountpoint is queryable within 5  seconds. If it's not the script exists with a fatal error and sets the  node to unhealthly.
If left unattended, this can lead to workers being unable to delete  Docker containers causing a "Zombie" effect.
At the time of this patch going in, the culprit is an issue with a CVMFS  repo.