### PR TITLE
Bump memory of test busybox container to 10m from 7m

### DIFF
--- a/healthcheck_wn_condor
+++ b/healthcheck_wn_condor
@@ -374,7 +374,7 @@ then
     fi
 
  # Check that containers can be created successfully
-    sudo /usr/bin/docker run --rm -m 7m busybox date >/dev/null 2>&1
+    sudo /usr/bin/docker run --rm -m 10m busybox date >/dev/null 2>&1
     RC=$?
     if [ $RC -ne 0 ]
     then


### PR DESCRIPTION
There exists a very rare condition where the busybox container will not  start with 7m of memory allocation, even though all processes happily  fit within this allocation. Interestingly this issue is more prevalent  on nodes with more than 500GB of RAM in the host. Raising allocation to  10m