### PR TITLE
Bump container memory limit to 3x requested memory

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -74,7 +74,7 @@ def args_create(argv):
         m = re.search(r'--memory=([\d]+)m', arg)
         if m:
             memory = int(m.group(1))
-            dargs.append('--memory=%dm' % (memory*2))
+            dargs.append('--memory=%dm' % (memory*3))
             dargs.append('--memory-reservation=%dm' % memory)
         else:
             dargs.append(arg)


### PR DESCRIPTION
This 3x container limit is then in-line with the limit configured in  Condor