### PR TITLE
Increase xrootd stream timeout

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -66,6 +66,10 @@ def args_create(argv):
         dargs.append('--env=SINGULARITYENV_XrdSecGSISRVNAMES=%s' % getfqdn())
         # ATLAS fix for 21.0.XX release errors with frontier
         dargs.append('--env=FRONTIER_LOG_FILE=frontier.log')
+        #Increase timeout to prevent vector read errors
+        dargs.append('--env=XRD_STREAMTIMEOUT=300')
+        dargs.append('--env=APPTAINERENV_XRD_STREAMTIMEOUT=300')
+        dargs.append('--env=SINGULARITYENV_XRD_STREAMTIMEOUT=300')
     else:
         dargs.append('--label=xrootd-local-gateway=false')
 


### PR DESCRIPTION
For effective operation of vector read requests stream tiemout should be increased, default value (1 minute) is not enough. There are two reasons for this:
1. Sometimes ceph operations can take longer than one minute. This is especially true for unhealty cluster.
2. With the prefetch off xrootd services are less "tolerant" to restarts. This is because proxy usually recovers faster after the restart. Since client talks to proxy, when it is covered it will immediately request new data. With prefetch off this data is unlikely to be present in local cache, therefore requests is likely to be forwarded to gateway. Since gateway usually requires more time to recover, default timeout may be exceeded.