### PR TITLE
Bump the memory limit on the busybox container to use 64mb.

### DIFF
--- a/healthcheck_wn_condor
+++ b/healthcheck_wn_condor
@@ -374,7 +374,7 @@ then
     fi
 
  # Check that containers can be created successfully
-    sudo /usr/bin/docker run --rm -m 10m busybox date >/dev/null 2>&1
+    sudo /usr/bin/docker run --rm -m 64m busybox date >/dev/null 2>&1
     RC=$?
     if [ $RC -ne 0 ]
     then


### PR DESCRIPTION
This avoids any memory related issues with assigning cgroups to a container, most prevalent on Openstack VM's