### PR TITLE
feat: add gateway address to job containers

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -89,7 +89,7 @@ def args_create(argv):
         if primary_ipv6:
             primary_ipv6 = primary_ipv6.rstrip(':')
             dargs.append('--add-host=xrootd.echo.stfc.ac.uk ceph-gw10.gridpp.rl.ac.uk ceph-gw11.gridpp.rl.ac.uk:{}{}'.format(primary_ipv6, ':1000:2'))
-            dargs.append('--add-host=xrootd-gateway.echo.stfc.ac.uk:{}{}'.format(primary_ipv6, ':1000:2'))
+            dargs.append('--add-host=xrootd-gateway.echo.stfc.ac.uk:{}{}'.format(primary_ipv6, ':1000:3'))
         dargs.append('--env=XrdSecGSISRVNAMES=%s' % getfqdn())
         dargs.append('--env=APPTAINERENV_XrdSecGSISRVNAMES=%s' % getfqdn())
         # Singularity equivalent for backwards compatibility

--- a/docker.py
+++ b/docker.py
@@ -83,11 +83,13 @@ def args_create(argv):
         dargs.append('--label=xrootd-local-gateway=true')
         dargs.append('--network=ralworker')
         dargs.append('--add-host=xrootd.echo.stfc.ac.uk ceph-gw10.gridpp.rl.ac.uk ceph-gw11.gridpp.rl.ac.uk:172.28.1.1')
+        dargs.append('--add-host=xrootd-gateway.echo.stfc.ac.uk:172.28.1.2')
         # Call function to capture primary IPv6 address and assign xrootd alias to local containers IPv6 address.
         primary_ipv6 = get_primary_ipv6()
         if primary_ipv6:
             primary_ipv6 = primary_ipv6.rstrip(':')
             dargs.append('--add-host=xrootd.echo.stfc.ac.uk ceph-gw10.gridpp.rl.ac.uk ceph-gw11.gridpp.rl.ac.uk:{}{}'.format(primary_ipv6, ':1000:2'))
+            dargs.append('--add-host=xrootd-gateway.echo.stfc.ac.uk:{}{}'.format(primary_ipv6, ':1000:2'))
         dargs.append('--env=XrdSecGSISRVNAMES=%s' % getfqdn())
         dargs.append('--env=APPTAINERENV_XrdSecGSISRVNAMES=%s' % getfqdn())
         # Singularity equivalent for backwards compatibility


### PR DESCRIPTION
We are testing a setup with writeable WN gateways, where proxy redirects write requests to the local gateway. In order for this to work, jobs should be able to map gateway's name to its address and vice-a-versa.