### PR TITLE
Add Docker switch to deny SWAP usage in job container

### DIFF
--- a/docker.py
+++ b/docker.py
@@ -76,6 +76,7 @@ def args_create(argv):
         if m:
             memory = int(m.group(1))
             dargs.append('--memory=%dm' % (memory*3))
+            dargs.append('--memory-swap=%dm' % (memory*3))
             dargs.append('--memory-reservation=%dm' % memory)
         else:
             dargs.append(arg)


### PR DESCRIPTION
We already allow a job to utilise 3 times the requested memory. Given this, any SWAP usage will be from jobs abusing memory or memory leaking. Either way SWAP should be disabled